### PR TITLE
Use ES6-syntax for import/require

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurora-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Aurora Application Assembler Core",
   "main": "index.js",
   "engines": {

--- a/src/decorators/with-redux.js
+++ b/src/decorators/with-redux.js
@@ -1,12 +1,12 @@
 /**
  * Dependencies
  */
-const React = require('react');
-const hoistStatics = require('hoist-non-react-statics');
-const { createStore, applyMiddleware, compose } = require('redux');
-const thunk = require('redux-thunk');
-const createLogger = require('redux-logger');
-const { Provider } = require('react-redux');
+import React from 'react';
+import hoistStatics from 'hoist-non-react-statics';
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunk from 'redux-thunk';
+import createLogger from 'redux-logger';
+import { Provider } from 'react-redux';
 
 /**
  * Higher order component factory


### PR DESCRIPTION
`redux-thunk` does not handle ES5 require syntax anymore without adding `.default`