### PR TITLE
unmountComponent, when rendering a new component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ eslintrc.json-ci-runner
 #########
 .idea
 *.iml
+bundle-hash.js

--- a/dist/decorators/with-data.js
+++ b/dist/decorators/with-data.js
@@ -22,7 +22,7 @@ var DataMixin = require('../mixins/data-mixin');
 module.exports = function (_ref) {
   var _ref$fetchData = _ref.fetchData;
   var fetchData = _ref$fetchData === undefined ? function () {
-    return Promise.resolve;
+    return Promise.resolve();
   } : _ref$fetchData;
   var _ref$dataProp = _ref.dataProp;
   var dataProp = _ref$dataProp === undefined ? 'data' : _ref$dataProp;

--- a/dist/render/client.js
+++ b/dist/render/client.js
@@ -214,7 +214,7 @@ module.exports = function () {
        * the application
        */
       return new Promise(function (resolve) {
-        ReactDOM.render(React.createElement(
+        var app = ReactDOM.render(React.createElement(
           ContextWrapper,
           {
             actions: {},
@@ -232,6 +232,11 @@ module.exports = function () {
         function () {
           return resolve();
         });
+        if (window.ReactApp) {
+          ReactDOM.unmountComponentAtNode(window.ReactApp);
+        }
+        window.ReactApp = app;
+        return app;
       });
     })
     /**

--- a/src/render/client.js
+++ b/src/render/client.js
@@ -191,7 +191,7 @@ module.exports = function ({
        * the application
        */
       return new Promise((resolve) => {
-        ReactDOM.render(
+        const app = ReactDOM.render(
           <ContextWrapper
             actions={{}}
             settings={settings}
@@ -209,6 +209,11 @@ module.exports = function ({
            */
           () => resolve()
         );
+        if(window.ReactApp) {
+          ReactDOM.unmountComponentAtNode(window.ReactApp);
+        }
+        window.ReactApp = app;
+        return app;
       });
     })
     /**


### PR DESCRIPTION
In facebook documentation it recommends to unmount when you run `React.render` severalt times to not leak memory.  See https://facebook.github.io/react/blog/2015/10/01/react-render-and-top-level-api.html

Also:
1. Also added bundle-hash.js to .gitignore, since that is just a placeholder that is updated on every build.
2. Seems like `dist/decorator/with-data.js` has a change. I guess I use a different minor version of some build lib, that has this change!  
